### PR TITLE
add endpoint for GET /api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -49,6 +49,34 @@ describe("/api", () => {
 });
 
 describe("/api/articles", () => {
+  test("GET: 200 responds with an array of articles objects", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.articles.length).toBe(13);
+        body.articles.forEach((article) => {
+          expect(article).toMatchObject({
+            author: expect.any(String),
+            title: expect.any(String),
+            article_id: expect.any(Number),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: expect.any(Number),
+            article_img_url: expect.any(String),
+            comment_count: expect.any(Number),
+          });
+          expect(article).not.toHaveProperty("body");
+        });
+      });
+  });
+  test("GET: 200 responds with an array of articles sorted by date in descending order", () => {
+    return request(app)
+      .get("/api/articles")
+      .then(({ body }) => {
+        expect(body.articles).toBeSortedBy("created_at", { descending: true });
+      });
+  });
   describe("/:article_id", () => {
     test("GET: 200 responds with a single article, by article_id", () => {
       return request(app)

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const {
   getTopics,
   getEndPoints,
   getArticleById,
+  getArticles,
 } = require("./controllers/app.controllers");
 
 const express = require("express");
@@ -13,6 +14,8 @@ app.get("/api/topics", getTopics);
 app.get("/api", getEndPoints);
 
 app.get("/api/articles/:article_id", getArticleById);
+
+app.get("/api/articles", getArticles);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Endpoint not found!" });

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -2,6 +2,7 @@ const {
   fetchTopics,
   fetchEndPoints,
   fetchArticleById,
+  fetchArticles,
 } = require("../models/app.models");
 
 module.exports.getTopics = (req, res, next) => {
@@ -24,6 +25,16 @@ module.exports.getArticleById = (req, res, next) => {
   fetchArticleById(article_id)
     .then((article) => {
       res.status(200).send({ article });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports.getArticles = (req, res, next) => {
+  fetchArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
     })
     .catch((err) => {
       next(err);

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -21,3 +21,13 @@ module.exports.fetchArticleById = (id) => {
       return rows[0];
     });
 };
+
+module.exports.fetchArticles = () => {
+  const queryStr = `SELECT 
+    author, title, article_id, topic, created_at, votes, article_img_url,
+    (SELECT COUNT(*)::int FROM comments WHERE comments.article_id = articles.article_id) as comment_count
+    FROM articles ORDER BY created_at DESC;`;
+  return db.query(queryStr).then(({ rows }) => {
+    return rows;
+  });
+};

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
add endpoint for GET /api/articles reponding with an array of articles sorted by date, containing author, title, article_id, topic, created_at, votes, article_img_url, comment_count (and not body)