### PR TITLE
add endpoint for GET /api/articles/:article_id/comments

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -112,4 +112,58 @@ describe("/api/articles", () => {
         });
     });
   });
+  describe("/:article_id/comments", () => {
+    test("GET: 200 responds with an array of comments for the given article_id", () => {
+      return request(app)
+        .get("/api/articles/1/comments")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comments.length).toBe(11);
+          body.comments.forEach((comment) => {
+            expect(comment).toMatchObject({
+              comment_id: expect.any(Number),
+              votes: expect.any(Number),
+              created_at: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+              article_id: expect.any(Number),
+            });
+          });
+        });
+    });
+    test("GET: 200 responds with an array of comments, sorted by date (most recent first - descending)", () => {
+      return request(app)
+        .get("/api/articles/1/comments")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comments).toBeSortedBy("created_at", {
+            descending: true,
+          });
+        });
+    });
+    test("GET: 200 responds with an empty array for an article_id that exists but has no comments", () => {
+      return request(app)
+        .get("/api/articles/2/comments")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comments).toEqual([]);
+        });
+    });
+    test("GET: 404 responds with appropriate status and error message when given a valid but non-existent id", () => {
+      return request(app)
+        .get("/api/articles/50/comments")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Article does not exist");
+        });
+    });
+    test("GET: 400 responds with appropriate status and error message when given an invalid id", () => {
+      return request(app)
+        .get("/api/articles/squirrels/comments")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Bad Request: invalid id (must be an integer)");
+        });
+    });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -3,7 +3,10 @@ const {
   getEndPoints,
   getArticleById,
   getArticles,
+  getCommentsByArticleId,
 } = require("./controllers/app.controllers");
+
+const { psqlErrorHandler } = require("./error-handlers");
 
 const express = require("express");
 
@@ -17,18 +20,16 @@ app.get("/api/articles/:article_id", getArticleById);
 
 app.get("/api/articles", getArticles);
 
+app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
+
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Endpoint not found!" });
 });
 
+app.use(psqlErrorHandler);
+
 app.use((err, req, res, next) => {
-  if (err.status === 404) {
-    res.status(404).send(err);
-  }
-  if (err.code === "22P02") {
-    res
-      .status(400)
-      .send({ msg: "Bad Request: invalid id (must be an integer)" });
-  }
+  res.status(err.status).send(err);
 });
+
 module.exports = app;

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -3,7 +3,10 @@ const {
   fetchEndPoints,
   fetchArticleById,
   fetchArticles,
+  fetchCommentsById,
 } = require("../models/app.models");
+
+const { checkArticleExists } = require("../utils");
 
 module.exports.getTopics = (req, res, next) => {
   fetchTopics()
@@ -35,6 +38,20 @@ module.exports.getArticles = (req, res, next) => {
   fetchArticles()
     .then((articles) => {
       res.status(200).send({ articles });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports.getCommentsByArticleId = (req, res, next) => {
+  const { article_id } = req.params;
+  const articleExistsQuery = checkArticleExists(article_id);
+  const fetchCommentsQuery = fetchCommentsById(article_id);
+  Promise.all([articleExistsQuery, fetchCommentsQuery])
+    .then((response) => {
+      const comments = response[1];
+      res.status(200).send({ comments });
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -21,6 +21,23 @@
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }
   },
+  "GET /api/articles/:article_id": {
+    "description": "serves a single article, found by article_id",
+    "queries": [],
+    "requestBodyFormat": {},
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "author": "weegembump",
+        "title": "Seafood substitutions are increasing",
+        "topic": "cooking",
+        "body": "Text from the article..",
+        "created_at": "2018-05-30T15:59:13.341Z",
+        "votes": 0,
+        "article_img_url": "url string here"
+      }
+    }
+  },
   "GET /api/articles": {
     "description": "serves an array of all articles",
     "queries": ["author", "topic", "sort_by", "order"],
@@ -35,6 +52,31 @@
           "created_at": "2018-05-30T15:59:13.341Z",
           "votes": 0,
           "comment_count": 6
+        }
+      ]
+    }
+  },
+  "GET /api/articles/:article_id/comments": {
+    "description": "serves a list of comments by article_id",
+    "queries": [],
+    "requestBodyFormat": {},
+    "exampleResponse": {
+      "comments": [
+        {
+          "comment_id": 15,
+          "body": "I am 100% sure that we're not completely sure.",
+          "article_id": 5,
+          "author": "butter_bridge",
+          "votes": 1,
+          "created_at": "2020-11-24T00:08:00.000Z"
+        },
+        {
+          "comment_id": 14,
+          "body": "'What do you see? I have no idea where this will lead us. This place I speak of, is known as the Black Lodge.'",
+          "article_id": 5,
+          "author": "icellusedkars",
+          "votes": 16,
+          "created_at": "2020-06-09T05:00:00.000Z"
         }
       ]
     }

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -1,0 +1,8 @@
+module.exports.psqlErrorHandler = (err, req, res, next) => {
+  if (err.code === "22P02") {
+    res
+      .status(400)
+      .send({ msg: "Bad Request: invalid id (must be an integer)" });
+  }
+  next(err);
+};

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -31,3 +31,10 @@ module.exports.fetchArticles = () => {
     return rows;
   });
 };
+
+module.exports.fetchCommentsById = (article_id) => {
+  const queryStr = `SELECT * FROM comments WHERE article_id = $1 ORDER BY created_at DESC;`;
+  return db.query(queryStr, [article_id]).then(({ rows }) => {
+    return rows;
+  });
+};

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,11 @@
+const db = require("./db/connection");
+
+module.exports.checkArticleExists = (article_id) => {
+  return db
+    .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({ status: 404, msg: "Article does not exist" });
+      }
+    });
+};


### PR DESCRIPTION
add endpoint for GET /api/articles/:article_id/comments, testing for 200 returning array of comments, in order of newest first, testing for 200 empty array for valid article_id that has no comments, tests for 404 article not found and 400 for invalid article_id (not an integer). add refactor of error handlers for readability.