### PR TITLE
add endpoint for POST /api/articles/:article_id/comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const {
   getArticleById,
   getArticles,
   getCommentsByArticleId,
+  postCommentByArticleId,
 } = require("./controllers/app.controllers");
 
 const { psqlErrorHandler } = require("./error-handlers");
@@ -11,6 +12,8 @@ const { psqlErrorHandler } = require("./error-handlers");
 const express = require("express");
 
 const app = express();
+
+app.use(express.json());
 
 app.get("/api/topics", getTopics);
 
@@ -21,6 +24,8 @@ app.get("/api/articles/:article_id", getArticleById);
 app.get("/api/articles", getArticles);
 
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
+
+app.post("/api/articles/:article_id/comments", postCommentByArticleId);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Endpoint not found!" });

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -4,6 +4,7 @@ const {
   fetchArticleById,
   fetchArticles,
   fetchCommentsById,
+  insertComment,
 } = require("../models/app.models");
 
 const { checkArticleExists } = require("../utils");
@@ -52,6 +53,21 @@ module.exports.getCommentsByArticleId = (req, res, next) => {
     .then((response) => {
       const comments = response[1];
       res.status(200).send({ comments });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports.postCommentByArticleId = (req, res, next) => {
+  const commentToPost = req.body;
+  const { article_id } = req.params;
+  const articleExistsQuery = checkArticleExists(article_id);
+  const insertCommentQuery = insertComment(commentToPost, article_id);
+  Promise.all([articleExistsQuery, insertCommentQuery])
+    .then((response) => {
+      const comment = response[1];
+      res.status(201).send({ comment });
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -80,5 +80,21 @@
         }
       ]
     }
+  },
+  "POST /api/articles/:article_id/comments": {
+    "description": "add a comment by article_id",
+    "queries": [],
+    "requestBodyFormat": {
+      "username": "username string",
+      "body": "comment body string"
+    },
+    "exampleResponse": {
+      "comment_id": 15,
+      "votes": 0,
+      "created_at": "2023-05-15 21:19:00",
+      "author": "username string",
+      "body": "comment body string",
+      "article_id": 11
+    }
   }
 }

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -4,5 +4,15 @@ module.exports.psqlErrorHandler = (err, req, res, next) => {
       .status(400)
       .send({ msg: "Bad Request: invalid id (must be an integer)" });
   }
+  if (err.code === "23502") {
+    res.status(400).send({
+      msg: "Invalid comment, couldn't post - make sure you include a body and username",
+    });
+  }
+  if (err.code === "23503") {
+    res.status(404).send({
+      msg: "Username not registered, couldn't post comment.",
+    });
+  }
   next(err);
 };

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -38,3 +38,11 @@ module.exports.fetchCommentsById = (article_id) => {
     return rows;
   });
 };
+
+module.exports.insertComment = (commentToPost, article_id) => {
+  const queryStr = `INSERT INTO comments (author, body, article_id) VALUES ($1, $2, $3) RETURNING *`;
+  const values = [commentToPost.username, commentToPost.body, article_id];
+  return db.query(queryStr, values).then(({ rows }) => {
+    return rows[0];
+  });
+};

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,10 @@ module.exports.checkArticleExists = (article_id) => {
     .query("SELECT * FROM articles WHERE article_id = $1", [article_id])
     .then(({ rows }) => {
       if (rows.length === 0) {
-        return Promise.reject({ status: 404, msg: "Article does not exist" });
+        return Promise.reject({
+          status: 404,
+          msg: `Couldn't find article ${article_id}`,
+        });
       }
     });
 };


### PR DESCRIPTION
add endpoint for POST /api/articles/:article_id/comments with 201 test for inserting new comment to database, 400 tests for invalid comments (missing username or body) or invalid article id (not an integer), 404 for article_id that is valid but doesn't exist, or when passed a valid comment but with invalid/unregistered username.