### PR TITLE
add endpoint for DELETE /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -322,3 +322,36 @@ describe("/api/articles", () => {
     });
   });
 });
+
+describe("/api/comments", () => {
+  describe("/:comments_id", () => {
+    test("DELETE: 204 sends 204 status after deleting comment from database", () => {
+      return request(app)
+        .delete("/api/comments/5")
+        .expect(204)
+        .then(() => {
+          return request(app)
+            .get("/api/articles/1/comments")
+            .then(({ body }) => {
+              expect(body.comments.length).toBe(10);
+            });
+        });
+    });
+    test("DELETE: 404 responds with appropriate status and message if comment_id is valid (an integer) but not found", () => {
+      return request(app)
+        .delete("/api/comments/60")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Couldn't find comment 60");
+        });
+    });
+    test("DELETE: 400 responds with appropriate status and message if comment_id is invalid (not an integer)", () => {
+      return request(app)
+        .delete("/api/comments/nonsnsenotanid")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Bad Request: invalid id (must be an integer)");
+        });
+    });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const {
   getCommentsByArticleId,
   postCommentByArticleId,
   patchArticleVotesById,
+  deleteCommentByCommentId,
 } = require("./controllers/app.controllers");
 
 const { psqlErrorHandler } = require("./error-handlers");
@@ -29,6 +30,8 @@ app.patch("/api/articles/:article_id", patchArticleVotesById);
 app.get("/api/articles/:article_id/comments", getCommentsByArticleId);
 
 app.post("/api/articles/:article_id/comments", postCommentByArticleId);
+
+app.delete("/api/comments/:comment_id", deleteCommentByCommentId);
 
 app.all("*", (req, res) => {
   res.status(404).send({ msg: "Endpoint not found!" });

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -6,9 +6,10 @@ const {
   fetchCommentsById,
   insertComment,
   updateArticleVotesById,
+  removeCommentByCommentId,
 } = require("../models/app.models");
 
-const { checkArticleExists } = require("../utils");
+const { checkArticleExists, checkCommentExists } = require("../utils");
 
 module.exports.getTopics = (req, res, next) => {
   fetchTopics()
@@ -96,4 +97,17 @@ module.exports.patchArticleVotesById = (req, res, next) => {
         next(err);
       });
   }
+};
+
+module.exports.deleteCommentByCommentId = (req, res, next) => {
+  const { comment_id } = req.params;
+  const checkCommentExistsQuery = checkCommentExists(comment_id);
+  const removeCommentQuery = removeCommentByCommentId(comment_id);
+  Promise.all([removeCommentQuery, checkCommentExistsQuery])
+    .then((response) => {
+      res.sendStatus(204);
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -115,5 +115,11 @@
         "article_img_url": "url string here"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "removes a single comment from database (by ID)",
+    "queries": [],
+    "requestBodyFormat": {},
+    "exampleResponse": {}
   }
 }

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -58,3 +58,8 @@ module.exports.updateArticleVotesById = (updatedVoteCount, article_id) => {
       return rows[0];
     });
 };
+
+module.exports.removeCommentByCommentId = (comment_id) => {
+  const queryStr = `DELETE FROM comments WHERE comment_id = $1`;
+  return db.query(queryStr, [comment_id]);
+};

--- a/utils.js
+++ b/utils.js
@@ -12,3 +12,16 @@ module.exports.checkArticleExists = (article_id) => {
       }
     });
 };
+
+module.exports.checkCommentExists = (comment_id) => {
+  return db
+    .query(`SELECT * FROM comments WHERE comment_id= $1`, [comment_id])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: `Couldn't find comment ${comment_id}`,
+        });
+      }
+    });
+};


### PR DESCRIPTION
add endpoint for DELETE /api/comments/:comment_id, tests for 204 returning nothing but removing comment from database, 404 for valid but non-existent comment_id, 400 for invalid comment_id.