### PR TITLE
add endpoint for GET /api/articles (topic query)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -77,6 +77,42 @@ describe("/api/articles", () => {
         expect(body.articles).toBeSortedBy("created_at", { descending: true });
       });
   });
+  describe("?topic", () => {
+    test("GET: 200 responds with an array sorted by topic value specified in the query", () => {
+      return request(app)
+        .get("/api/articles?topic=cats")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles.length).toBe(1);
+          expect(body.articles[0]).toMatchObject({
+            author: "rogersop",
+            title: "UNCOVERED: catspiracy to bring down democracy",
+            article_id: 5,
+            topic: "cats",
+            created_at: expect.any(String),
+            article_img_url:
+              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+            comment_count: 2,
+          });
+        });
+    });
+    test("GET: 200 responds with an empty array when passed a topic that exists but with with no articles", () => {
+      return request(app)
+        .get("/api/articles?topic=paper")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles.length).toBe(0);
+        });
+    });
+    test("GET: 404 responds with an appropriate status code and error message when provided with a non-existent topic", () => {
+      return request(app)
+        .get("/api/articles?topic=dogs")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Couldn't find topic: dogs in the database.");
+        });
+    });
+  });
   describe("/:article_id", () => {
     test("GET: 200 responds with a single article, by article_id", () => {
       return request(app)

--- a/controllers/app.controllers.js
+++ b/controllers/app.controllers.js
@@ -10,7 +10,11 @@ const {
   fetchUsers,
 } = require("../models/app.models");
 
-const { checkArticleExists, checkCommentExists } = require("../utils");
+const {
+  checkArticleExists,
+  checkCommentExists,
+  checkTopicExists,
+} = require("../utils");
 
 module.exports.getTopics = (req, res, next) => {
   fetchTopics()
@@ -39,8 +43,16 @@ module.exports.getArticleById = (req, res, next) => {
 };
 
 module.exports.getArticles = (req, res, next) => {
-  fetchArticles()
-    .then((articles) => {
+  const { topic } = req.query;
+  const getTopicsArticlesQuery = fetchArticles(topic);
+  const promiseArr = [getTopicsArticlesQuery];
+  if (topic) {
+    const topicExistsQuery = checkTopicExists(topic);
+    promiseArr.push(topicExistsQuery);
+  }
+  Promise.all(promiseArr)
+    .then((response) => {
+      const articles = response[0];
       res.status(200).send({ articles });
     })
     .catch((err) => {

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const { checkTopicExists } = require("../utils");
 
 module.exports.fetchTopics = () => {
   return db.query("SELECT * FROM topics").then(({ rows }) => {
@@ -22,12 +23,18 @@ module.exports.fetchArticleById = (id) => {
     });
 };
 
-module.exports.fetchArticles = () => {
-  const queryStr = `SELECT 
+module.exports.fetchArticles = (topic) => {
+  const queries = [];
+  let queryStr = `SELECT 
     author, title, article_id, topic, created_at, votes, article_img_url,
     (SELECT COUNT(*)::int FROM comments WHERE comments.article_id = articles.article_id) as comment_count
-    FROM articles ORDER BY created_at DESC;`;
-  return db.query(queryStr).then(({ rows }) => {
+    FROM articles`;
+  if (topic) {
+    queryStr += ` WHERE topic = $1`;
+    queries.push(topic);
+  }
+  queryStr += ` ORDER BY created_at DESC;`;
+  return db.query(queryStr, queries).then(({ rows }) => {
     return rows;
   });
 };

--- a/utils.js
+++ b/utils.js
@@ -25,3 +25,16 @@ module.exports.checkCommentExists = (comment_id) => {
       }
     });
 };
+
+module.exports.checkTopicExists = (topic) => {
+  return db
+    .query(`SELECT * FROM topics WHERE slug = $1`, [topic])
+    .then(({ rows }) => {
+      if (rows.length === 0) {
+        return Promise.reject({
+          status: 404,
+          msg: `Couldn't find topic: ${topic} in the database.`,
+        });
+      }
+    });
+};


### PR DESCRIPTION
add endpoint for GET /api/articles (topic query), 200 test for sorting by topic, returning an empty array for a topic that exists in database but has no associated articles, and a 404 test when provided with a non-existent topic 