### PR TITLE
add endpoint PATCH /api/comments/:comment_id

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -246,6 +246,26 @@ describe("/api/articles", () => {
           });
         });
     });
+    test("PATCH: 200 responds with article unchanged if request body is missing inc_votes", () => {
+      return request(app)
+        .patch("/api/articles/11")
+        .send({
+          votes: 10,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.article).toMatchObject({
+            article_id: 11,
+            author: "icellusedkars",
+            title: "Am I a cat?",
+            body: expect.any(String),
+            topic: expect.any(String),
+            created_at: expect.any(String),
+            votes: 0,
+            article_img_url: expect.any(String),
+          });
+        });
+    });
     test("PATCH: 404 responds with appropriate status and error message when given a valid but non-existent id", () => {
       const votesToUpdate = {
         inc_votes: 12,
@@ -268,20 +288,6 @@ describe("/api/articles", () => {
         .expect(400)
         .then(({ body }) => {
           expect(body.msg).toBe("Bad Request: invalid id (must be an integer)");
-        });
-    });
-    test("PATCH: 400 responds with appropriate status and error message when provided with an invalid request body (missing inc_votes)", () => {
-      const votesToUpdate = {
-        wrong_key: 12,
-      };
-      return request(app)
-        .patch("/api/articles/2")
-        .send(votesToUpdate)
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe(
-            "Invalid request - must include inc_votes which must have an integer value"
-          );
         });
     });
     test("PATCH: 400 responds with appropriate status and error message when provided with an invalid request body (inc_votes is not given with an integer value)", () => {
@@ -465,6 +471,78 @@ describe("/api/comments", () => {
         .expect(400)
         .then(({ body }) => {
           expect(body.msg).toBe("Bad Request: invalid id (must be an integer)");
+        });
+    });
+    test("PATCH: 200 responds with updated comment after updating the votes count on comment, given the comment's comment_id", () => {
+      return request(app)
+        .patch("/api/comments/1")
+        .send({
+          inc_votes: 10,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comment).toMatchObject({
+            comment_id: 1,
+            body: expect.any(String),
+            article_id: 9,
+            author: "butter_bridge",
+            votes: 26,
+            created_at: expect.any(String),
+          });
+        });
+    });
+    test("PATCH: 200 responds with comment unchanged if request body is missing inc_votes", () => {
+      return request(app)
+        .patch("/api/comments/1")
+        .send({
+          votes: 10,
+        })
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.comment).toMatchObject({
+            comment_id: 1,
+            body: expect.any(String),
+            article_id: 9,
+            author: "butter_bridge",
+            votes: 16,
+            created_at: expect.any(String),
+          });
+        });
+    });
+    test("PATCH: 404 responds with appropriate status code and error message when provided with a valid but non-existent comment_id", () => {
+      return request(app)
+        .patch("/api/comments/11111111")
+        .send({
+          inc_votes: 10,
+        })
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Couldn't find comment 11111111");
+        });
+    });
+    test("PATCH: 400 responds with appropriate status code and error message when provided with an invalid comment_id (not an int)", () => {
+      return request(app)
+        .patch("/api/comments/notanid")
+        .send({
+          inc_votes: 10,
+        })
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("Bad Request: invalid id (must be an integer)");
+        });
+    });
+    test("PATCH: 400 responds with appropriate status and error message when provided with an invalid request body (inc_votes is not given with an integer value)", () => {
+      const votesToUpdate = {
+        inc_votes: "twelve",
+      };
+      return request(app)
+        .patch("/api/comments/2")
+        .send(votesToUpdate)
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe(
+            "Invalid request - must include inc_votes which must have an integer value"
+          );
         });
     });
   });

--- a/models/app.models.js
+++ b/models/app.models.js
@@ -113,3 +113,18 @@ module.exports.fetchUserByUsername = (username) => {
     return rows[0];
   });
 };
+
+module.exports.fetchCommentByCommentId = (comment_id) => {
+  const queryStr = `SELECT * FROM comments WHERE comment_id = $1`;
+  return db.query(queryStr, [comment_id]).then(({ rows }) => {
+    return rows[0];
+  });
+};
+
+module.exports.updateCommentByCommentId = (comment_id, newVoteCount) => {
+  const queryValues = [newVoteCount, comment_id];
+  const queryStr = `UPDATE comments SET votes = $1 WHERE comment_id = $2 RETURNING *`;
+  return db.query(queryStr, queryValues).then(({ rows }) => {
+    return rows[0];
+  });
+};

--- a/routes/comments-router.js
+++ b/routes/comments-router.js
@@ -1,7 +1,13 @@
-const { deleteCommentByCommentId } = require("../controllers/app.controllers");
+const {
+  deleteCommentByCommentId,
+  patchCommentByCommentId,
+} = require("../controllers/app.controllers");
 
 const commentsRouter = require("express").Router();
 
-commentsRouter.route("/:comment_id").delete(deleteCommentByCommentId);
+commentsRouter
+  .route("/:comment_id")
+  .delete(deleteCommentByCommentId)
+  .patch(patchCommentByCommentId);
 
 module.exports = commentsRouter;

--- a/utils.js
+++ b/utils.js
@@ -38,3 +38,12 @@ module.exports.checkTopicExists = (topic) => {
       }
     });
 };
+
+module.exports.checkValidIncVotes = (inc_votes) => {
+  if (typeof inc_votes !== "number") {
+    return Promise.reject({
+      status: 400,
+      msg: "Invalid request - must include inc_votes which must have an integer value",
+    });
+  }
+};


### PR DESCRIPTION
add endpoint PATCH /api/comments/:comment_id. 200 serves updated comment if passed valid request, 200 serves unchanged comment if request body missing inc_votes, 404 for comment not found, 400 for invalid comment_id (not int) and inc_votes in request body not given as a int value.