### PR TITLE
add endpoint GET /api/articles (pagination)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -54,7 +54,6 @@ describe("/api/articles", () => {
       .get("/api/articles")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles.length).toBe(13);
         body.articles.forEach((article) => {
           expect(article).toMatchObject({
             author: expect.any(String),
@@ -198,7 +197,6 @@ describe("/api/articles", () => {
         expect(body.msg).toBe("Article body cannot be an empty string");
       });
   });
-
   describe("?topic", () => {
     test("GET: 200 responds with an array sorted by topic value specified in the query", () => {
       return request(app)
@@ -295,6 +293,62 @@ describe("/api/articles", () => {
         });
     });
   });
+  //PAGINATION
+  describe("?p & limit", () => {
+    test("GET: 200 takes optional limit (limits the number of responses) querie, and responds with the articles paginated according to the limit provided", () => {
+      return request(app)
+        .get("/api/articles?limit=5")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles.length).toBe(5);
+        });
+    });
+    test("GET: 200 takes additional p query (specifies the page at which to start) and responds with the array paginated according to the limit and page provided", () => {
+      return request(app)
+        .get("/api/articles?limit=5&p=3")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles.length).toBe(3);
+        });
+    });
+    test("GET: 200 returns paginated array and a total_count property (which displays the total number of articles with any filters applied, discounting the limit)", () => {
+      return request(app)
+        .get("/api/articles?limit=5&p=3")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.total_count).toBe(13);
+        });
+    });
+    test("GET: 200 returns paginated array, with limit defaulting to 10 if not provided", () => {
+      return request(app)
+        .get("/api/articles?p=2")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.articles.length).toBe(3);
+        });
+    });
+    test("GET: 400 responds with appropriate status code and error message if passed an invalid limit (must be an integer)", () => {
+      return request(app)
+        .get("/api/articles?limit=notalimit")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe(
+            "Invalid limit - can only limit by positive integers!"
+          );
+        });
+    });
+    test("GET: 400 responds with appropriate status code and error message if passed an invalid page number (must be an integer)", () => {
+      return request(app)
+        .get("/api/articles?p=notanumber")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe(
+            "Invalid page number - must be a positive integer!"
+          );
+        });
+    });
+  });
+
   describe("/:article_id", () => {
     test("GET: 200 responds with a single article, by article_id", () => {
       return request(app)

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -5,6 +5,7 @@ const {
   insertCommentByArticleId,
   updateArticleVotesByArticleId,
   insertArticle,
+  fetchTotalNumberOfArticles,
 } = require("../models/articles.models");
 
 const {
@@ -25,17 +26,23 @@ module.exports.getArticleById = (req, res, next) => {
 };
 
 module.exports.getArticles = (req, res, next) => {
-  const { topic, sort_by, order } = req.query;
-  const getArticlesQuery = fetchArticles(topic, sort_by, order);
-  const promiseArr = [getArticlesQuery];
+  const { topic, sort_by, order, limit, p } = req.query;
+
+  const getArticlesQuery = fetchArticles(topic, sort_by, order, limit, p);
+  const getTotalsQuery = fetchTotalNumberOfArticles(topic);
+
+  const promiseArr = [getArticlesQuery, getTotalsQuery];
+
   if (topic) {
     const topicExistsQuery = checkTopicExists(topic);
     promiseArr.push(topicExistsQuery);
   }
+
   Promise.all(promiseArr)
     .then((response) => {
       const articles = response[0];
-      res.status(200).send({ articles });
+      const total_count = response[1];
+      res.status(200).send({ articles, total_count });
     })
     .catch((err) => {
       next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -41,7 +41,7 @@
   },
   "GET /api/articles": {
     "description": "serves an array of all articles",
-    "queries": ["author", "topic", "sort_by", "order"],
+    "queries": ["author", "topic", "sort_by", "order", "limit", "p"],
     "requestBodyFormat": {},
     "exampleResponse": {
       "article": [

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -1,13 +1,15 @@
 module.exports.psqlErrorHandler = (err, req, res, next) => {
+  let msg = err.detail;
+  // msg: "Bad Request: invalid id (must be an integer)"
   if (err.code === "22P02") {
-    res
-      .status(400)
-      .send({ msg: "Bad Request: invalid id (must be an integer)" });
+    if (err.line === "620")
+      msg = "Bad Request: invalid id (must be an integer)";
+    if (err.line === "882")
+      msg = "Invalid limit - can only limit by positive integers!";
+
+    res.status(400).send({ msg });
   }
   if (err.code === "23502") {
-    // "Invalid comment, couldn't post - make sure you include a body and username"
-
-    let msg = err.detail;
     if (err.table === "comments")
       msg =
         "Invalid comment, couldn't post - make sure you include a body and username";
@@ -19,7 +21,6 @@ module.exports.psqlErrorHandler = (err, req, res, next) => {
     });
   }
   if (err.code === "23503") {
-    let msg = err.detail;
     if (err.detail.includes("topic"))
       msg = "Couldn't find that topic in the database.";
     if (err.detail.includes("author"))
@@ -28,5 +29,15 @@ module.exports.psqlErrorHandler = (err, req, res, next) => {
       msg,
     });
   }
+  if (err.code === "42703") {
+    res
+      .status(400)
+      .send({
+        status: 400,
+        msg: "Invalid page number - must be a positive integer!",
+      });
+  }
   next(err);
 };
+
+// code: '42703

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -18,7 +18,9 @@ module.exports.fetchArticleById = (id) => {
 module.exports.fetchArticles = (
   topic,
   sort_by = "created_at",
-  order = "desc"
+  order = "desc",
+  limit = 10,
+  p
 ) => {
   const greenListSortBys = [
     "created_at",
@@ -41,15 +43,33 @@ module.exports.fetchArticles = (
     queries.push(topic);
     queryStr += ` WHERE topic = $${queries.length}`;
   }
+  queries.push(limit);
+
+  let offset = 0;
+  if (p) offset = (p - 1) * limit;
 
   if (order.toLowerCase() === "asc") {
-    queryStr += ` ORDER BY ${sort_by};`;
+    queryStr += ` ORDER BY ${sort_by} `;
   } else {
-    queryStr += ` ORDER BY ${sort_by} DESC;`;
+    queryStr += ` ORDER BY ${sort_by} DESC`;
   }
+
+  queryStr += ` LIMIT $${queries.length} OFFSET ${offset};`;
 
   return db.query(queryStr, queries).then(({ rows }) => {
     return rows;
+  });
+};
+
+module.exports.fetchTotalNumberOfArticles = (topic) => {
+  const queries = [];
+  let queryStr = `SELECT * FROM articles`;
+  if (topic) {
+    queries.push(topic);
+    queryStr += ` WHERE topic = $1 ;`;
+  }
+  return db.query(queryStr, queries).then(({ rows }) => {
+    return rows.length;
   });
 };
 


### PR DESCRIPTION
add endpoint GET /api/articles adding optional queries limit (defaults to 10) and p (for page number), 200 tests for responding with articles and total_count property, 400 tests for invalid limit or p (not ints)