### PR TITLE
add endpoint GET /api/articles/:article_id/comments (pagination)

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -293,9 +293,8 @@ describe("/api/articles", () => {
         });
     });
   });
-  //PAGINATION
   describe("?p & limit", () => {
-    test("GET: 200 takes optional limit (limits the number of responses) querie, and responds with the articles paginated according to the limit provided", () => {
+    test("GET: 200 takes optional limit (limits the number of responses) query, and responds with the articles paginated according to the limit provided", () => {
       return request(app)
         .get("/api/articles?limit=5")
         .expect(200)
@@ -332,9 +331,7 @@ describe("/api/articles", () => {
         .get("/api/articles?limit=notalimit")
         .expect(400)
         .then(({ body }) => {
-          expect(body.msg).toBe(
-            "Invalid limit - can only limit by positive integers!"
-          );
+          expect(body.msg).toBe("Invalid input - must be a positive integer!");
         });
     });
     test("GET: 400 responds with appropriate status code and error message if passed an invalid page number (must be an integer)", () => {
@@ -342,9 +339,7 @@ describe("/api/articles", () => {
         .get("/api/articles?p=notanumber")
         .expect(400)
         .then(({ body }) => {
-          expect(body.msg).toBe(
-            "Invalid page number - must be a positive integer!"
-          );
+          expect(body.msg).toBe("Invalid input - must be a positive integer!");
         });
     });
   });
@@ -487,7 +482,6 @@ describe("/api/articles", () => {
         .get("/api/articles/1/comments")
         .expect(200)
         .then(({ body }) => {
-          expect(body.comments.length).toBe(11);
           body.comments.forEach((comment) => {
             expect(comment).toMatchObject({
               comment_id: expect.any(Number),
@@ -613,6 +607,52 @@ describe("/api/articles", () => {
         .then(({ body }) => {
           expect(body.msg).toBe("Username not registered, couldn't post.");
         });
+    });
+    describe("?p & limit", () => {
+      test("GET: 200 takes optional limit (limits the number of responses) query, and responds with the comments paginated according to the limit provided", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=5")
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.comments.length).toBe(5);
+          });
+      });
+      test("GET: 200 takes additional p query (specifies the page at which to start) and responds with the array paginated according to the limit and page provided", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=5&p=3")
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.comments.length).toBe(1);
+          });
+      });
+      test("GET: 200 returns paginated array, with limit defaulting to 10 if not provided", () => {
+        return request(app)
+          .get("/api/articles/1/comments?p=2")
+          .expect(200)
+          .then(({ body }) => {
+            expect(body.comments.length).toBe(1);
+          });
+      });
+      test("GET: 400 responds with appropriate status code and error message if passed an invalid limit (must be an integer)", () => {
+        return request(app)
+          .get("/api/articles/1/comments?limit=notalimit")
+          .expect(400)
+          .then(({ body }) => {
+            expect(body.msg).toBe(
+              "Invalid input - must be a positive integer!"
+            );
+          });
+      });
+      test("GET: 400 responds with appropriate status code and error message if passed an invalid page number (must be an integer)", () => {
+        return request(app)
+          .get("/api/articles/1/comments?p=notanumber")
+          .expect(400)
+          .then(({ body }) => {
+            expect(body.msg).toBe(
+              "Invalid input - must be a positive integer!"
+            );
+          });
+      });
     });
   });
 });

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -51,8 +51,9 @@ module.exports.getArticles = (req, res, next) => {
 
 module.exports.getCommentsByArticleId = (req, res, next) => {
   const { article_id } = req.params;
+  const { limit, p } = req.query;
   const articleExistsQuery = checkArticleExists(article_id);
-  const fetchCommentsQuery = fetchCommentsByArticleId(article_id);
+  const fetchCommentsQuery = fetchCommentsByArticleId(article_id, limit, p);
   Promise.all([articleExistsQuery, fetchCommentsQuery])
     .then((response) => {
       const comments = response[1];

--- a/error-handlers.js
+++ b/error-handlers.js
@@ -1,11 +1,10 @@
 module.exports.psqlErrorHandler = (err, req, res, next) => {
   let msg = err.detail;
-  // msg: "Bad Request: invalid id (must be an integer)"
+
   if (err.code === "22P02") {
     if (err.line === "620")
       msg = "Bad Request: invalid id (must be an integer)";
-    if (err.line === "882")
-      msg = "Invalid limit - can only limit by positive integers!";
+    if (err.line === "882") msg = "Invalid input - must be a positive integer!";
 
     res.status(400).send({ msg });
   }
@@ -29,15 +28,5 @@ module.exports.psqlErrorHandler = (err, req, res, next) => {
       msg,
     });
   }
-  if (err.code === "42703") {
-    res
-      .status(400)
-      .send({
-        status: 400,
-        msg: "Invalid page number - must be a positive integer!",
-      });
-  }
   next(err);
 };
-
-// code: '42703


### PR DESCRIPTION
add endpoint GET /api/articles/:article_id/comments (pagination) adding optional queries limit (defaults to 10) and p (for page number), 200 tests for responding with comments limited and at page as provided, 400 tests for invalid limit or p (not ints)